### PR TITLE
Add DF Wiki page

### DIFF
--- a/wiki.md
+++ b/wiki.md
@@ -1,0 +1,12 @@
+---
+title: DF Wiki
+layout: page
+---
+
+This project doesn't aim to be a wiki to Dwarf Fortress at all. There is already a vast and masterwork-quality [Dwarf Fortress Wiki](http://dwarffortresswiki.org/), to which you must go if you have any gameplay doubts.
+
+This site aims to be a repository for some schematics that I use more often, and to serve as inspiration to others seeking schematics and organizational designs.
+
+Please, do visit the [Dwarf Fortress Wiki](http://dwarffortresswiki.org/)!
+
+[![Website](https://img.shields.io/website/http/dwarffortresswiki.org?label=Dwarf%20Fortress%20Wiki&logo=wikipedia&logoColor=success&style=for-the-badge)](http://dwarffortresswiki.org/)


### PR DESCRIPTION
A page to refer to the [Dwarf Fortress Wiki](http://dwarffortresswiki.org/).

[![Website](https://img.shields.io/website/http/dwarffortresswiki.org?label=Dwarf%20Fortress%20Wiki&logo=wikipedia&logoColor=success&style=for-the-badge)](http://dwarffortresswiki.org/)

- **Added:**
  - A DF Wiki notice page.